### PR TITLE
Cannot access colors unless declared in the signature file

### DIFF
--- a/src/fchalk/fchalk.fsi
+++ b/src/fchalk/fchalk.fsi
@@ -27,3 +27,29 @@ val cprintf: color: System.ConsoleColor -> str: Printf.StringFormat<'a, unit> ->
 /// **Exceptions**
 ///
 val cprintfn: color: System.ConsoleColor -> str: Printf.StringFormat<'a, unit> -> 'a
+
+
+/// **Description**
+/// Colors
+/// **Parameters**
+/// **Output Type**
+/// **Exceptions**
+val red: System.ConsoleColor
+val darkRed: System.ConsoleColor
+val blue: System.ConsoleColor
+val darkBlue: System.ConsoleColor
+val green: System.ConsoleColor
+val darkGreen: System.ConsoleColor
+val yellow: System.ConsoleColor
+val darkYellow: System.ConsoleColor
+val cyan: System.ConsoleColor
+val darkCyan: System.ConsoleColor
+val gray: System.ConsoleColor
+val darkGray: System.ConsoleColor
+val grey: System.ConsoleColor
+val darkGrey: System.ConsoleColor
+val white: System.ConsoleColor
+val magenta: System.ConsoleColor
+val darkMagenta: System.ConsoleColor
+val black: System.ConsoleColor
+

--- a/src/fchalk/fchalk.fsproj
+++ b/src/fchalk/fchalk.fsproj
@@ -8,7 +8,7 @@
     <PackageId>fchalk</PackageId>      
     <Description>A simple utility library for colorizing console output in F#.</Description>
     <Authors>Josh DeGraw</Authors>
-    <PackageVersion>1.0.3.1</PackageVersion>
+    <PackageVersion>1.0.3.2</PackageVersion>
     <PackageTags>chalk, color, console, fsharp</PackageTags>
     <RepositoryUrl>https://github.com/josh-degraw/fchalk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Cannot access colors after installing the library through `nuget`
unless declared in the signature file. Currently it's like:

`cprintfn System.ConsoleColor.Yellow "Hello world"`

when I would expect:

`cprintf yellow "Hello world"`